### PR TITLE
Add cookie name option; improve adherence to Standard code style; 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Name | Type | Default | Required | Description
 **data** | `Array` | | | Override the default and populate the `<select>` with your own data in the required data structure <sup>`[1]`</sup>
 **expiry** | `number`, `Infinity`, `Date` | `0` | | Sets the expiration of the cookie in seconds. `0` is session-only. `Infinity` is forever. Supply a [Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) for any custom length of time
 **domain** | `String` | `null` | | Cookie path
+**name** | `String` | `old_enough` | | Cookie name
 
 **`[1]`** Format each country's data in an `Object`, and set the country order in the enclosing `Array`. For example:
 
@@ -101,4 +102,3 @@ data = [
 
 #### `Callback(err)`
 Pass a callback function as the second parameter. This will be called after the form submit event. The parameter `err` will return `null` if age verification succeeds, otherwise it will be an `Error` type. This is where you would typically write your action based on the response, e.g. redirect to a new URL, or hide the age gate view.
-

--- a/dist/index.js
+++ b/dist/index.js
@@ -145,13 +145,13 @@
     }, {
       key: 'verify',
       value: function verify(formData) {
-        var ok = false,
-            legalAge = this.ages[formData.country] || this.legalAge;
+        var ok = false;
+        var legalAge = this.ages[formData.country] || this.legalAge;
         var bday = [parseInt(formData.year, 10), parseInt(formData.month, 10) || 1, parseInt(formData.day, 10) || 1].join('/');
         var age = ~ ~((new Date().getTime() - +new Date(bday)) / 31557600000);
 
         if (age >= legalAge) {
-          var expiry = !!formData.remember ? this.options.expiry : null;
+          var expiry = formData.remember ? this.options.expiry : null;
           this.saveCookie(expiry);
 
           ok = true;
@@ -173,7 +173,7 @@
         var path = this.options.path || null;
         var domain = this.options.domain || null;
 
-        _cookies2['default'].setItem('old_enough', true, expiry, path, domain);
+        _cookies2['default'].setItem(this.options.name || 'old_enough', true, expiry, path, domain);
       }
 
       /**

--- a/example/agegate.js
+++ b/example/agegate.js
@@ -1,7 +1,8 @@
-import AgeGate from '../dist/index';
+import AgeGate from '../dist/index'
 
 let options = {
   form: document.querySelector('form[name=agegate]'),
+  name: 'old_enough_custom_name',
   countries: true,
   expiry: Infinity,
   data: [
@@ -9,15 +10,11 @@ let options = {
     { code: 'UK', name: 'United Kingdom', age: 18 },
     { code: 'US', name: 'United States of America', age: 21 }
   ]
-};
+}
 
-document.addEventListener('DOMContentLoaded', function() {
-
-  window.gate = new AgeGate(options, (err) => {
-    if (err)
-      throw new Error(err.message);
-    else
-      console.log(`siq1 m8`);
-  });
-
-});
+document.addEventListener('DOMContentLoaded', function () {
+  window.gate = new AgeGate(options, err => {
+    if (err) throw new Error(err.message)
+    else console.log(`siq1 m8`)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agegate",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Limit access to your app with an age gate",
   "main": "dist/index.js",
   "repository": {

--- a/src/data.js
+++ b/src/data.js
@@ -41,7 +41,7 @@ export var Africa = [
   { code: 'UG', name: 'Uganda', age: 18 },
   { code: 'ZM', name: 'Zambia', age: 18 },
   { code: 'ZW', name: 'Zimbabwe', age: 18 }
-];
+]
 
 export var America = [
   { code: 'AG', name: 'Antigua and Barbuda', age: 16 },
@@ -78,7 +78,7 @@ export var America = [
   { code: 'VI', name: 'United States Virgin Islands', age: 18 },
   { code: 'UY', name: 'Uruguay', age: 18 },
   { code: 'VE', name: 'Venezuela', age: 18 }
-];
+]
 
 export var Asia = [
   { code: 'AF', name: 'Afghanistan', age: Infinity },
@@ -121,7 +121,7 @@ export var Asia = [
   { code: 'AE', name: 'United Arab Emirates', age: 21 },
   { code: 'VN', name: 'Vietnam', age: 0 },
   { code: 'YE', name: 'Yemen', age: Infinity }
-];
+]
 
 export var Europe = [
   { code: 'AL', name: 'Albania', age: 18 },
@@ -171,7 +171,7 @@ export var Europe = [
   { code: 'TR', name: 'Turkey', age: 18 },
   { code: 'UA', name: 'Ukraine', age: 18 },
   { code: 'GB', name: 'United Kingdom', age: 18 }
-];
+]
 
 export var Oceania = [
   { code: 'AS', name: 'American Samoa', age: 21 },
@@ -188,4 +188,4 @@ export var Oceania = [
   { code: 'TK', name: 'Tokelau', age: 18 },
   { code: 'TO', name: 'Tonga', age: 21 },
   { code: 'VU', name: 'Vanuatu', age: 18 }
-];
+]

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import cookies from './cookies'
 const FORM_ELEMENTS = ['year', 'month', 'day', 'country', 'remember']
 
 export default class AgeGate {
-  constructor(opts, cb) {
+  constructor (opts, cb) {
     this.options = opts
     this.callback = cb
     this.isEnabled.data && this.validateData(opts.data)
@@ -17,7 +17,7 @@ export default class AgeGate {
   /**
    * Getters & Setters
    */
-  get isEnabled() {
+  get isEnabled () {
     return {
       age: !!this.options.age,
       countries: !!this.options.countries,
@@ -25,18 +25,18 @@ export default class AgeGate {
     }
   }
 
-  get legalAge() {
+  get legalAge () {
     return parseInt(this.options.age, 10) || 18
   }
 
-  get data() {
+  get data () {
     return this.options.data || data
   }
 
   /**
    * Convert age data into usable key => value
    */
-  get ages() {
+  get ages () {
     let ages = {}
 
     if (this.options.data) {
@@ -44,8 +44,7 @@ export default class AgeGate {
         total[item.code] = item.age
         return total
       }, ages)
-    }
-    else {
+    } else {
       for (let cont in this.data) {
         this.data[cont].map(country => ages[country.code] = country.age)
       }
@@ -72,30 +71,31 @@ export default class AgeGate {
   /**
    * Add countries to <select> element
    */
-  populate() {
+  populate () {
     let select = this.options.form.querySelector('select')
     select.innerHTML = '' // assume it's not empty
 
     // attempt to use user-supplied data
-    if (this.isEnabled.data)
-      this.data.forEach(country => select.appendChild( createOption(country) ))
+    if (this.isEnabled.data) this.data.forEach(country => select.appendChild(createOption(country)))
 
     // fallback to default data (continent-separated)
-    else Object.keys(data).forEach(continent => {
-      let group = document.createElement('optgroup')
-      group.label = continent
+    else {
+      Object.keys(data).forEach(continent => {
+        let group = document.createElement('optgroup')
+        group.label = continent
 
-      // create the <option> for each country
-      for (let i=0; i < data[continent].length; i++) {
-        let country = data[continent][i]
-        group.appendChild( createOption(country) )
-      }
+        // create the <option> for each country
+        for (let i = 0; i < data[continent].length; i++) {
+          let country = data[continent][i]
+          group.appendChild(createOption(country))
+        }
 
-      select.appendChild(group)
-    })
+        select.appendChild(group)
+      })
+    }
 
     // create the <option> element
-    function createOption(country) {
+    function createOption (country) {
       let option = document.createElement('option')
 
       for (let attr in country) {
@@ -114,7 +114,7 @@ export default class AgeGate {
    *
    * @param {Event} e - form submit event
    */
-  submit(e) {
+  submit (e) {
     e.preventDefault()
 
     let elements = e.target.elements
@@ -135,7 +135,7 @@ export default class AgeGate {
       return collection
     }, {})
 
-    this.respond( this.verify(this.formData) )
+    this.respond(this.verify(this.formData))
   }
 
   /**
@@ -147,7 +147,8 @@ export default class AgeGate {
    * @param {Object} formData
    */
   verify (formData) {
-    let ok = false, legalAge = this.ages[formData.country] || this.legalAge
+    let ok = false
+    let legalAge = this.ages[formData.country] || this.legalAge
     let bday = [
       parseInt(formData.year, 10),
       parseInt(formData.month, 10) || 1,
@@ -156,7 +157,7 @@ export default class AgeGate {
     let age = ~~((new Date().getTime() - +new Date(bday)) / (31557600000))
 
     if (age >= legalAge) {
-      let expiry = !!formData.remember? this.options.expiry : null
+      let expiry = formData.remember ? this.options.expiry : null
       this.saveCookie(expiry)
 
       ok = true
@@ -170,11 +171,11 @@ export default class AgeGate {
    *
    * @param {*} expiry - Cookie expiration (0|Infinity|Date)
    */
-  saveCookie (expiry=null) {
+  saveCookie (expiry = null) {
     const path = this.options.path || null
     const domain = this.options.domain || null
 
-    cookies.setItem('old_enough', true, expiry, path, domain)
+    cookies.setItem(this.options.name || 'old_enough', true, expiry, path, domain)
   }
 
   /**
@@ -183,7 +184,7 @@ export default class AgeGate {
    * @param {boolean} success - Age verification verdict
    * @param {string} message - Error message
    */
-  respond (success=false, message='Age verification failure') {
+  respond (success = false, message = 'Age verification failure') {
     if (success) this.callback(null)
     else this.callback(new Error(`[AgeGate] ${message}`))
   }


### PR DESCRIPTION
As the new default cookie name will be the same as before this isn't a breaking change - users will see no difference after updating unless they choose to add a new cookie name. Check the commit in this PR, it's fairly self-explanatory. We have this up on a live site now so are confident it's good to merge into here now.
